### PR TITLE
Fix: `IllegalArgumentException` when calling `terminate` method on android 

### DIFF
--- a/android/src/main/java/com/machine/thee/presentation/CapacitorPresentationPlugin.java
+++ b/android/src/main/java/com/machine/thee/presentation/CapacitorPresentationPlugin.java
@@ -63,7 +63,7 @@ public class CapacitorPresentationPlugin extends Plugin {
   }
 
   @PluginMethod
-  public void terminate() {
+  public void terminate(PluginCall call) {
     display.dismiss();
   }
 


### PR DESCRIPTION
Fixes #7 